### PR TITLE
Imports and baseclass

### DIFF
--- a/constrainedmf/__init__.py
+++ b/constrainedmf/__init__.py
@@ -1,4 +1,6 @@
 from ._version import get_versions
+from . import nmf  # noqa: F401
+from .nmf.models import NMF  # noqa: F401
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/constrainedmf/nmf/models.py
+++ b/constrainedmf/nmf/models.py
@@ -86,16 +86,16 @@ class NMFBase(nn.Module):
             Shape of the components matrix
         n_components: int
             Number of components in the factorization
-        initial_components: list of torch.Tensor
-            Initial components for the factorization
-        fix_components: list of bool
+        initial_components: tuple of torch.Tensor
+            Initial components for the factorization. Shape (1, n_features)
+        fix_components: tuple of bool
             Corresponding directive to fix each component in the factorization.
             The components are ordered, and the default behavior is to allow a component to vary.
             I.e. (True, False, True) for a 4 component factorization will result in the first and third
             component being fixed, while the second and fourth vary.
-        initial_weights: list of torch.Tensor
-            Initial weights for the factorization
-        fix_weights: list of bool
+        initial_weights: tuple of torch.Tensor
+            Initial weights for the factorization. Shape (1, m_examples)
+        fix_weights: tuple of bool
             Corresponding directive to fix each weight in the factorization.
         device: str, torch.device, None
             Device for matrix factorization to proceed on. Defaults to cpu.
@@ -112,7 +112,10 @@ class NMFBase(nn.Module):
             self.device = torch.device(device)
 
         if initial_weights is not None:
-            w_list = [nn.Parameter(weight) for weight in initial_weights]
+            w_list = [nn.Parameter(weight) for weight in initial_weights] + [
+                nn.Parameter(torch.rand(1, *W_shape[1:]))
+                for _ in range(W_shape[0] - len(initial_weights))
+            ]
         else:
             w_list = [
                 nn.Parameter(torch.rand(1, *W_shape[1:])) for _ in range(W_shape[0])
@@ -123,7 +126,10 @@ class NMFBase(nn.Module):
         self.W_list = nn.ParameterList(w_list).to(device)
 
         if initial_components is not None:
-            h_list = [nn.Parameter(component) for component in initial_components]
+            h_list = [nn.Parameter(component) for component in initial_components] + [
+                nn.Parameter(torch.rand(1, *H_shape[1:]))
+                for _ in range(H_shape[0] - len(initial_components))
+            ]
         else:
             h_list = [
                 nn.Parameter(torch.rand(1, *H_shape[1:])) for _ in range(H_shape[0])
@@ -336,16 +342,16 @@ class NMF(NMFBase):
             Tuple of ints describing shape of input matrix
         n_components: int
             Number of desired components for the matrix factorization
-        initial_components: list of torch.Tensor
-            Initial components for the factorization
-        fix_components: list of bool
+        initial_components: tuple of torch.Tensor
+            Initial components for the factorization. Shape (1, n_features)
+        fix_components: tuple of bool
             Corresponding directive to fix each component in the factorization.
             The components are ordered, and the default behavior is to allow a component to vary.
             I.e. (True, False, True) for a 4 component factorization will result in the first and third
             component being fixed, while the second and fourth vary.
-        initial_weights: list of torch.Tensor
-            Initial weights for the factorization
-        fix_weights: list of bool
+        initial_weights: tuple of torch.Tensor
+            Initial weights for the factorization. Shape (1, m_examples)
+        fix_weights: tuple of bool
             Corresponding directive to fix each weight in the factorization.
         device: str, torch.device, None
             Device for matrix factorization to proceed on. Defaults to cpu.

--- a/constrainedmf/nmf/models.py
+++ b/constrainedmf/nmf/models.py
@@ -304,8 +304,8 @@ class NMFBase(nn.Module):
         return losses
 
     def fit_transform(self, *args, **kwargs):
-        n_iter = self.fit(*args, **kwargs)
-        return n_iter, torch.cat([x for x in self.W_list])
+        self.fit(*args, **kwargs)
+        return self.W
 
 
 class NMF(NMFBase):

--- a/constrainedmf/tests/test_nmf.py
+++ b/constrainedmf/tests/test_nmf.py
@@ -46,3 +46,14 @@ def test_constrained_components(linearly_mixed_gaussians):
     )
     nmf.fit(xs)
     assert torch.all(torch.eq(components, nmf.H))
+
+
+def test_relative_imports():
+    from types import ModuleType
+    import constrainedmf as cmf
+    import constrainedmf.nmf as nmf
+
+    assert isinstance(cmf.nmf, ModuleType)
+    assert issubclass(cmf.NMF, cmf.nmf.models.NMFBase)
+    assert issubclass(cmf.nmf.models.NMF, cmf.nmf.models.NMFBase)
+    assert issubclass(nmf.models.NMF, nmf.models.NMFBase)

--- a/docs/source/nativeCMF.rst
+++ b/docs/source/nativeCMF.rst
@@ -18,6 +18,8 @@ Simple NMF
 
 A simple, albeit nonsensical, example of NMF can be accomplished with the following, starting from a matrix of 30 different 100 member vectors.
 We can constrain the components to be zeros and ones, and allow a third component to approximate the variation.
+This approach gives us the learning curve of the alternating update algorithm,
+and two numpy arrays of weights and components.
 
 .. code-block:: python
 
@@ -31,7 +33,8 @@ We can constrain the components to be zeros and ones, and allow a third componen
                                3,
                                initial_components=[x_0, x_1],
                                fix_components=[True, True, False])
-    H, W = model.fit_transform(X)
+    loss = model.fit(X) # Learning curve of loss over timesteps
+    learned_weights, learned_components = model.W.detach().numpy(), model.H.detach().numpy()
 
 
 

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,13 @@
 Release History
 ===============
 
+NEXT
+----
+
+- Address scope and convenience imports. The nmf module is accesible at the top level, as well as the NMF class.
+  :code:`cmf.nmf...` and :code:`cmf.NMF(...)`.
+- More flexibility at torch level with constraints. Allows for partial initialization of componenents and weights, and
+  partial specification of constraints.
 
 v0.1.1 (2021-11-?)
 -------------------


### PR DESCRIPTION
Closes #22. Took the scripts that were failing for @DanOlds and extended them as unit tests. 

Adds some scope and relative import to the `__init__`s. 

`NMF` class and `nmf` module are now available at the top level import. This enables `cmf.nmf...` calls, and `cmf.NMF(...)` construction. 