### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: Documentation
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,4 +1,6 @@
 name: Check Code Style
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v2
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Deploy documentation
       # We pin to the SHA, not the tag, for security reasons.
       # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-      uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501  # v3.7.3
+      uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
       with:
         deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
         publish_branch: master

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,7 +26,8 @@ jobs:
 
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 1000  # should be enough to reach the most recent tag
+        fetch-depth: 1000
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,6 @@
 name: Unit Tests
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
